### PR TITLE
Redesign Design Era toggle as visual style swatches

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,17 +1,14 @@
-# Netlify configuration for the Astro static blog
+# Netlify configuration for Astro project
 [build]
   command = "npm run build"
+  functions = "netlify/functions"
   publish = "dist"
 
 [build.environment]
-  # Astro 5 requires Node >= 18.20.8; pin explicitly so deploys
-  # don't fall back to an older .nvmrc / default image.
-  NODE_VERSION = "20.19.0"
-  NPM_FLAGS = "--no-audit --no-fund"
+  NODE_VERSION = "18.20.8"
 
-# Multi-page static site: do not SPA-fallback everything to index.html.
-# Keep pretty URLs for nested post directories.
+# Rewrite rules for SPA routing
 [[redirects]]
-  from = "/blog"
-  to = "/blog/"
-  status = 301
+  from = "/*"
+  to = "/index.html"
+  status = 200

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,11 +1,17 @@
-# Netlify configuration for Astro project
+# Netlify configuration for the Astro static blog
 [build]
   command = "npm run build"
-  functions = "netlify/functions"
   publish = "dist"
 
-# Rewrite rules for SPA routing
+[build.environment]
+  # Astro 5 requires Node >= 18.20.8; pin explicitly so deploys
+  # don't fall back to an older .nvmrc / default image.
+  NODE_VERSION = "20.19.0"
+  NPM_FLAGS = "--no-audit --no-fund"
+
+# Multi-page static site: do not SPA-fallback everything to index.html.
+# Keep pretty URLs for nested post directories.
 [[redirects]]
-  from = "/*"
-  to = "/index.html"
-  status = 200
+  from = "/blog"
+  to = "/blog/"
+  status = 301

--- a/src/components/TrendToggle.astro
+++ b/src/components/TrendToggle.astro
@@ -39,35 +39,63 @@ const eras = [
 ] as const;
 ---
 
-<section class="trend-toggle" aria-label="Design era selector">
-  <div class="trend-toggle-intro">
-    <p class="trend-toggle-kicker">Design Era</p>
-    <p class="trend-toggle-current" id="trend-badge-label">Default · Original Blog</p>
-  </div>
+<section class="trend-toggle" data-expanded="false" aria-label="Design era selector">
+  <button
+    type="button"
+    class="trend-toggle-summary"
+    id="trend-toggle-trigger"
+    aria-expanded="false"
+    aria-controls="trend-toggle-panel"
+  >
+    <span class="trend-toggle-summary-preview trend-swatch-preview trend-swatch-preview--default" id="trend-summary-preview" aria-hidden="true">
+      <span class="trend-swatch-chrome"></span>
+      <span class="trend-swatch-body"></span>
+      <span class="trend-swatch-accent"></span>
+    </span>
 
-  <div class="trend-toggle-swatches" role="toolbar" aria-label="Choose a design era">
-    {
-      eras.map((era) => (
-        <button
-          type="button"
-          class="trend-swatch"
-          data-era={era.id}
-          aria-pressed="false"
-          aria-label={`${era.name}, ${era.years}`}
-          title={`${era.name} · ${era.years}`}
-        >
-          <span class={`trend-swatch-preview trend-swatch-preview--${era.id}`} aria-hidden="true">
-            <span class="trend-swatch-chrome" />
-            <span class="trend-swatch-body" />
-            <span class="trend-swatch-accent" />
-          </span>
-          <span class="trend-swatch-meta">
-            <span class="trend-swatch-name">{era.name}</span>
-            <span class="trend-swatch-years">{era.years}</span>
-          </span>
-        </button>
-      ))
-    }
+    <span class="trend-toggle-summary-copy">
+      <span class="trend-toggle-kicker">Design Era</span>
+      <span class="trend-toggle-current" id="trend-badge-label">Default · Original Blog</span>
+    </span>
+
+    <span class="trend-toggle-summary-action">
+      <span class="trend-toggle-action-label" data-label-expand>Change</span>
+      <span class="trend-toggle-action-label" data-label-collapse hidden>Close</span>
+      <span class="trend-toggle-chevron" aria-hidden="true"></span>
+    </span>
+  </button>
+
+  <div
+    class="trend-toggle-panel"
+    id="trend-toggle-panel"
+    role="region"
+    aria-labelledby="trend-toggle-trigger"
+    hidden
+  >
+    <div class="trend-toggle-swatches" role="toolbar" aria-label="Choose a design era">
+      {
+        eras.map((era) => (
+          <button
+            type="button"
+            class="trend-swatch"
+            data-era={era.id}
+            aria-pressed="false"
+            aria-label={`${era.name}, ${era.years}`}
+            title={`${era.name} · ${era.years}`}
+          >
+            <span class={`trend-swatch-preview trend-swatch-preview--${era.id}`} aria-hidden="true">
+              <span class="trend-swatch-chrome" />
+              <span class="trend-swatch-body" />
+              <span class="trend-swatch-accent" />
+            </span>
+            <span class="trend-swatch-meta">
+              <span class="trend-swatch-name">{era.name}</span>
+              <span class="trend-swatch-years">{era.years}</span>
+            </span>
+          </button>
+        ))
+      }
+    </div>
   </div>
 </section>
 
@@ -84,7 +112,30 @@ const eras = [
     flat: 'Flat / Material · 2013–20',
   };
 
-  function applyTrend(trend: string) {
+  const root = document.querySelector<HTMLElement>('.trend-toggle');
+  const trigger = document.getElementById('trend-toggle-trigger') as HTMLButtonElement | null;
+  const panel = document.getElementById('trend-toggle-panel');
+  const summaryPreview = document.getElementById('trend-summary-preview');
+  const expandLabel = document.querySelector<HTMLElement>('[data-label-expand]');
+  const collapseLabel = document.querySelector<HTMLElement>('[data-label-collapse]');
+
+  function setExpanded(expanded: boolean) {
+    if (!root || !trigger || !panel) return;
+
+    root.dataset.expanded = String(expanded);
+    trigger.setAttribute('aria-expanded', String(expanded));
+    panel.hidden = !expanded;
+
+    if (expandLabel) expandLabel.hidden = expanded;
+    if (collapseLabel) collapseLabel.hidden = !expanded;
+
+    if (expanded) {
+      const active = root.querySelector<HTMLButtonElement>('.trend-swatch.active');
+      active?.focus();
+    }
+  }
+
+  function applyTrend(trend: string, options: { collapse?: boolean } = {}) {
     document.documentElement.setAttribute('data-trend', trend);
     localStorage.setItem(STORAGE_KEY, trend);
 
@@ -96,14 +147,33 @@ const eras = [
 
     const badge = document.getElementById('trend-badge-label');
     if (badge) badge.textContent = trendLabels[trend] ?? trend;
+
+    if (summaryPreview) {
+      summaryPreview.className = `trend-toggle-summary-preview trend-swatch-preview trend-swatch-preview--${trend}`;
+    }
+
+    if (options.collapse) setExpanded(false);
   }
 
   const saved = localStorage.getItem(STORAGE_KEY) ?? DEFAULT_TREND;
   applyTrend(saved);
+  setExpanded(false);
+
+  trigger?.addEventListener('click', () => {
+    const next = root?.dataset.expanded !== 'true';
+    setExpanded(next);
+  });
 
   document.querySelectorAll<HTMLButtonElement>('.trend-swatch[data-era]').forEach((btn) => {
     btn.addEventListener('click', () => {
-      if (btn.dataset.era) applyTrend(btn.dataset.era);
+      if (btn.dataset.era) applyTrend(btn.dataset.era, { collapse: true });
     });
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape' && root?.dataset.expanded === 'true') {
+      setExpanded(false);
+      trigger?.focus();
+    }
   });
 </script>

--- a/src/components/TrendToggle.astro
+++ b/src/components/TrendToggle.astro
@@ -1,19 +1,75 @@
 ---
-// TrendToggle.astro
-// Drop into src/components/TrendToggle.astro
+const eras = [
+  {
+    id: 'default',
+    name: 'Default',
+    years: 'Original',
+    label: 'Default · Original Blog',
+  },
+  {
+    id: 'liquid-glass',
+    name: 'Liquid Glass',
+    years: '2025–26',
+    label: 'Liquid Glass · 2025–26',
+  },
+  {
+    id: 'glassmorphism',
+    name: 'Glassmorphism',
+    years: '2021–24',
+    label: 'Glassmorphism · 2021–24',
+  },
+  {
+    id: 'brutalism',
+    name: 'Brutalism',
+    years: 'Timeless',
+    label: 'Brutalism · Timeless',
+  },
+  {
+    id: 'skeuomorphism',
+    name: 'Skeuomorphism',
+    years: '2007–13',
+    label: 'Skeuomorphism · 2007–13',
+  },
+  {
+    id: 'flat',
+    name: 'Flat',
+    years: '2013–20',
+    label: 'Flat / Material · 2013–20',
+  },
+] as const;
 ---
 
-<div class="trend-toggle-bar" role="toolbar" aria-label="Design trend selector">
-  <span class="trend-toggle-label">Design Era &nbsp;&nbsp;&dash;</span>
-  <div class="trend-toggle-buttons">
-    <button class="trend-btn" data-era="default">Default</button>
-    <button class="trend-btn" data-era="liquid-glass">Liquid Glass</button>
-    <button class="trend-btn" data-era="glassmorphism">Glassmorphism</button>
-    <button class="trend-btn" data-era="brutalism">Brutalism</button>
-    <button class="trend-btn" data-era="skeuomorphism">Skeuomorphism</button>
-    <button class="trend-btn" data-era="flat">Flat</button>
+<section class="trend-toggle" aria-label="Design era selector">
+  <div class="trend-toggle-intro">
+    <p class="trend-toggle-kicker">Design Era</p>
+    <p class="trend-toggle-current" id="trend-badge-label">Default · Original Blog</p>
   </div>
-</div>
+
+  <div class="trend-toggle-swatches" role="toolbar" aria-label="Choose a design era">
+    {
+      eras.map((era) => (
+        <button
+          type="button"
+          class="trend-swatch"
+          data-era={era.id}
+          aria-pressed="false"
+          aria-label={`${era.name}, ${era.years}`}
+          title={`${era.name} · ${era.years}`}
+        >
+          <span class={`trend-swatch-preview trend-swatch-preview--${era.id}`} aria-hidden="true">
+            <span class="trend-swatch-chrome" />
+            <span class="trend-swatch-body" />
+            <span class="trend-swatch-accent" />
+          </span>
+          <span class="trend-swatch-meta">
+            <span class="trend-swatch-name">{era.name}</span>
+            <span class="trend-swatch-years">{era.years}</span>
+          </span>
+        </button>
+      ))
+    }
+  </div>
+</section>
 
 <script>
   const STORAGE_KEY = 'blog-design-era';
@@ -32,27 +88,22 @@
     document.documentElement.setAttribute('data-trend', trend);
     localStorage.setItem(STORAGE_KEY, trend);
 
-    document
-      .querySelectorAll<HTMLButtonElement>('.trend-toggle-bar [data-era]')
-      .forEach((btn) => {
-        btn.classList.toggle('active', btn.dataset.era === trend);
-        btn.setAttribute('aria-pressed', String(btn.dataset.era === trend));
-      });
+    document.querySelectorAll<HTMLButtonElement>('.trend-swatch[data-era]').forEach((btn) => {
+      const isActive = btn.dataset.era === trend;
+      btn.classList.toggle('active', isActive);
+      btn.setAttribute('aria-pressed', String(isActive));
+    });
 
     const badge = document.getElementById('trend-badge-label');
     if (badge) badge.textContent = trendLabels[trend] ?? trend;
   }
 
-  // Restore on load
   const saved = localStorage.getItem(STORAGE_KEY) ?? DEFAULT_TREND;
   applyTrend(saved);
 
-  // Wire up buttons
-  document
-    .querySelectorAll<HTMLButtonElement>('.trend-toggle-bar [data-era]')
-    .forEach((btn) => {
-      btn.addEventListener('click', () => {
-        if (btn.dataset.era) applyTrend(btn.dataset.era);
-      });
+  document.querySelectorAll<HTMLButtonElement>('.trend-swatch[data-era]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      if (btn.dataset.era) applyTrend(btn.dataset.era);
     });
+  });
 </script>

--- a/src/styles/trends.css
+++ b/src/styles/trends.css
@@ -529,102 +529,365 @@ html[data-trend='glassmorphism'] body::before {
   Then use bg-blog-bg, text-blog-primary etc. in your templates.
 */
 
-/* ─── TREND TOGGLE BAR STYLES ──────────────────────────────────── */
-.trend-toggle-bar {
+/* ─── DESIGN ERA SWATCH PICKER ─────────────────────────────────── */
+.trend-toggle {
   position: relative;
   z-index: 20;
   isolation: isolate;
-  pointer-events: auto;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 0.5rem;
-  padding: 0.375rem 0.5rem;
+  display: grid;
+  gap: 0.85rem;
+  width: min(960px, calc(100% - 2rem));
+  margin: 0 auto 2.25rem;
+  padding: 1rem 1.1rem 1.15rem;
   background: var(--trend-surface);
   backdrop-filter: var(--trend-blur);
   -webkit-backdrop-filter: var(--trend-blur);
   border: 1px solid var(--trend-border);
+  border-radius: var(--trend-radius);
   box-shadow: var(--trend-shadow);
-  flex-wrap: wrap;
   transition: var(--trend-transition, all 0.4s ease);
-  margin-bottom: 2rem;
 }
 
-html[data-trend='brutalism'] .trend-toggle-bar {
+html[data-trend='brutalism'] .trend-toggle {
   border: 3px solid var(--trend-border);
+  border-radius: 0;
   box-shadow: 5px 5px 0 var(--trend-border-accent);
 }
 
-.trend-toggle-label {
-  font-size: 0.65rem;
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.12em;
-  color: var(--trend-toggle-label);
-  padding: 0 0.25rem;
-  white-space: nowrap;
-  flex-shrink: 0;
-  transition: color 0.4s ease;
-}
-
-.trend-toggle-buttons {
+.trend-toggle-intro {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.25rem;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.35rem 1rem;
 }
 
-.trend-btn {
-  position: relative;
-  z-index: 1;
-  padding: 0.3rem 0.65rem;
+.trend-toggle-kicker {
+  margin: 0;
   font-size: 0.68rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  color: var(--trend-toggle-label);
+}
+
+.trend-toggle-current {
+  margin: 0;
+  font-size: 0.82rem;
   font-weight: 600;
-  letter-spacing: 0.03em;
+  color: var(--trend-toggle-btn);
+  letter-spacing: 0.01em;
+}
+
+.trend-toggle-swatches {
+  display: grid;
+  grid-template-columns: repeat(6, minmax(0, 1fr));
+  gap: 0.55rem;
+}
+
+@media (max-width: 820px) {
+  .trend-toggle-swatches {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 480px) {
+  .trend-toggle {
+    width: calc(100% - 1rem);
+    padding: 0.85rem 0.75rem 1rem;
+  }
+
+  .trend-toggle-swatches {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+.trend-swatch {
+  appearance: none;
+  display: grid;
+  gap: 0.45rem;
+  padding: 0.45rem;
+  text-align: left;
   color: var(--trend-toggle-btn);
   background: var(--trend-toggle-btn-bg);
   border: 1px solid var(--trend-toggle-btn-border);
-  border-radius: var(--trend-radius-sm);
+  border-radius: calc(var(--trend-radius-sm) + 2px);
   cursor: pointer;
-  pointer-events: auto;
-  white-space: nowrap;
-  transition: var(--trend-transition, all 0.3s ease);
+  transition:
+    transform 0.25s ease,
+    border-color 0.3s ease,
+    background-color 0.3s ease,
+    box-shadow 0.3s ease,
+    color 0.3s ease;
 }
 
-.trend-btn:hover {
-  color: var(--trend-btn-active-color);
-  background: var(--trend-btn-active-bg);
+.trend-swatch:hover {
+  transform: translateY(-2px);
   border-color: var(--trend-btn-active-border);
-  box-shadow:
-    inset 0 0 0 1px var(--trend-btn-active-border),
-    0 2px 12px color-mix(in srgb, var(--color-accent), transparent 70%);
+  box-shadow: 0 8px 18px color-mix(in srgb, var(--color-accent), transparent 78%);
 }
 
-.trend-btn.active,
-.trend-btn[aria-pressed='true'] {
+.trend-swatch:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
+}
+
+.trend-swatch.active,
+.trend-swatch[aria-pressed='true'] {
   background: var(--trend-btn-active-bg);
   color: var(--trend-btn-active-color);
   border-color: var(--trend-btn-active-border);
   box-shadow: inset 0 0 0 1px var(--trend-btn-active-border);
 }
 
-html[data-trend='brutalism'] .trend-btn {
-  border: 2px solid transparent;
-  font-family: 'Space Mono', monospace;
-  font-size: 0.65rem;
-}
-html[data-trend='brutalism'] .trend-btn:hover {
-  border: 2px solid var(--trend-border);
-  box-shadow: 2px 2px 0 var(--trend-border-accent);
-}
-html[data-trend='brutalism'] .trend-btn.active {
-  border: 2px solid var(--trend-border);
-  box-shadow: 2px 2px 0 var(--trend-border-accent);
+.trend-swatch.active .trend-swatch-preview,
+.trend-swatch[aria-pressed='true'] .trend-swatch-preview {
+  transform: scale(1.02);
+  box-shadow: 0 6px 16px rgba(0, 0, 0, 0.18);
 }
 
-html[data-trend='skeuomorphism'] .trend-btn.active {
-  background: var(--trend-btn-active-bg);
-  color: var(--trend-btn-active-color);
-  border-color: var(--trend-btn-active-border);
+.trend-swatch-preview {
+  position: relative;
+  display: block;
+  overflow: hidden;
+  height: 3.1rem;
+  border-radius: calc(var(--trend-radius-sm) + 1px);
+  border: 1px solid rgba(0, 0, 0, 0.08);
+  transition:
+    transform 0.25s ease,
+    box-shadow 0.3s ease;
+}
+
+.trend-swatch-chrome,
+.trend-swatch-body,
+.trend-swatch-accent {
+  position: absolute;
+  display: block;
+  pointer-events: none;
+}
+
+.trend-swatch-meta {
+  display: grid;
+  gap: 0.1rem;
+  min-width: 0;
+}
+
+.trend-swatch-name {
+  font-size: 0.68rem;
+  font-weight: 700;
+  line-height: 1.2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trend-swatch-years {
+  font-size: 0.58rem;
+  font-weight: 500;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  opacity: 0.72;
+}
+
+/* Fixed miniature previews — each swatch keeps its own era look */
+.trend-swatch-preview--default {
+  background: linear-gradient(180deg, #0f4c81 42%, #f4f8fc 42%);
+}
+.trend-swatch-preview--default .trend-swatch-chrome {
+  inset: 0.35rem 0.4rem auto;
+  height: 0.28rem;
+  width: 42%;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.85);
+}
+.trend-swatch-preview--default .trend-swatch-body {
+  left: 0.4rem;
+  right: 0.4rem;
+  bottom: 0.45rem;
+  height: 0.7rem;
+  border-radius: 2px;
+  background: rgba(15, 76, 129, 0.18);
+}
+.trend-swatch-preview--default .trend-swatch-accent {
+  right: 0.4rem;
+  top: 0.35rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.55);
+}
+
+.trend-swatch-preview--liquid-glass {
+  background:
+    radial-gradient(circle at 20% 20%, rgba(126, 184, 255, 0.55), transparent 45%),
+    radial-gradient(circle at 80% 70%, rgba(180, 140, 255, 0.4), transparent 40%),
+    linear-gradient(145deg, #101222, #1a2038);
+}
+.trend-swatch-preview--liquid-glass .trend-swatch-chrome {
+  inset: 0.35rem;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.14);
+  border: 1px solid rgba(255, 255, 255, 0.28);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.35);
+  backdrop-filter: blur(4px);
+}
+.trend-swatch-preview--liquid-glass .trend-swatch-body {
+  left: 0.7rem;
+  right: 0.7rem;
+  top: 0.85rem;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.55);
+}
+.trend-swatch-preview--liquid-glass .trend-swatch-accent {
+  left: 0.7rem;
+  right: 1.4rem;
+  top: 1.45rem;
+  height: 0.28rem;
+  border-radius: 999px;
+  background: rgba(126, 184, 255, 0.55);
+}
+
+.trend-swatch-preview--glassmorphism {
+  background:
+    radial-gradient(circle at 15% 80%, rgba(200, 150, 255, 0.55), transparent 42%),
+    radial-gradient(circle at 85% 20%, rgba(100, 180, 255, 0.45), transparent 40%),
+    linear-gradient(160deg, #1a1035, #2a1848);
+}
+.trend-swatch-preview--glassmorphism .trend-swatch-chrome {
+  inset: 0.4rem 0.45rem;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.28);
+}
+.trend-swatch-preview--glassmorphism .trend-swatch-body {
+  left: 0.8rem;
+  right: 0.8rem;
+  top: 0.95rem;
+  height: 0.32rem;
+  border-radius: 999px;
+  background: rgba(240, 238, 255, 0.7);
+}
+.trend-swatch-preview--glassmorphism .trend-swatch-accent {
+  left: 0.8rem;
+  width: 35%;
+  top: 1.5rem;
+  height: 0.28rem;
+  border-radius: 999px;
+  background: rgba(200, 150, 255, 0.7);
+}
+
+.trend-swatch-preview--brutalism {
+  background: #f5f0e8;
+  border-color: #111 !important;
+  border-radius: 0 !important;
+  box-shadow: 3px 3px 0 #ff2d00;
+}
+.trend-swatch-preview--brutalism .trend-swatch-chrome {
+  left: 0.35rem;
+  right: 0.35rem;
+  top: 0.35rem;
+  height: 0.7rem;
+  background: #ffcc00;
+  border: 2px solid #111;
+}
+.trend-swatch-preview--brutalism .trend-swatch-body {
+  left: 0.35rem;
+  right: 0.35rem;
+  bottom: 0.35rem;
+  height: 0.85rem;
+  background: #fff;
+  border: 2px solid #111;
+}
+.trend-swatch-preview--brutalism .trend-swatch-accent {
+  right: 0.55rem;
+  bottom: 0.55rem;
+  width: 0.55rem;
+  height: 0.55rem;
+  background: #ff2d00;
+  border: 2px solid #111;
+}
+
+.trend-swatch-preview--skeuomorphism {
+  background: linear-gradient(180deg, #3f8fad 0%, #245f78 55%, #1d4d63 100%);
+  border-radius: 8px !important;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.35),
+    inset 0 -2px 4px rgba(0, 0, 0, 0.25);
+}
+.trend-swatch-preview--skeuomorphism .trend-swatch-chrome {
+  left: 0.45rem;
+  right: 0.45rem;
+  top: 0.4rem;
+  height: 0.9rem;
+  border-radius: 6px;
+  background: linear-gradient(180deg, #7ec8e4, #3f8fad);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.55),
+    0 2px 4px rgba(0, 0, 0, 0.25);
+}
+.trend-swatch-preview--skeuomorphism .trend-swatch-body {
+  left: 0.7rem;
+  right: 0.7rem;
+  top: 0.65rem;
+  height: 0.28rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.7);
+}
+.trend-swatch-preview--skeuomorphism .trend-swatch-accent {
+  left: 50%;
+  bottom: 0.4rem;
+  width: 1.1rem;
+  height: 0.35rem;
+  margin-left: -0.55rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.22);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.25);
+}
+
+.trend-swatch-preview--flat {
+  background: #fafafa;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.1);
+}
+.trend-swatch-preview--flat .trend-swatch-chrome {
+  inset: 0 auto auto 0;
+  width: 100%;
+  height: 0.55rem;
+  background: #1976d2;
+}
+.trend-swatch-preview--flat .trend-swatch-body {
+  left: 0.45rem;
+  right: 0.45rem;
+  top: 1rem;
+  height: 0.35rem;
+  border-radius: 2px;
+  background: #212121;
+  opacity: 0.75;
+}
+.trend-swatch-preview--flat .trend-swatch-accent {
+  left: 0.45rem;
+  width: 40%;
+  top: 1.55rem;
+  height: 0.28rem;
+  border-radius: 2px;
+  background: #1976d2;
+}
+
+html[data-trend='brutalism'] .trend-swatch {
+  border: 2px solid transparent;
+  border-radius: 0;
+  font-family: 'Space Mono', monospace;
+}
+
+html[data-trend='brutalism'] .trend-swatch:hover,
+html[data-trend='brutalism'] .trend-swatch.active {
+  border: 2px solid var(--trend-border);
+  box-shadow: 3px 3px 0 var(--trend-border-accent);
+  transform: translate(-1px, -1px);
+}
+
+html[data-trend='skeuomorphism'] .trend-swatch.active {
   box-shadow:
     inset 0 1px 0 rgba(255, 255, 255, 0.2),
     0 2px 4px rgba(0, 0, 0, 0.4);

--- a/src/styles/trends.css
+++ b/src/styles/trends.css
@@ -535,10 +535,9 @@ html[data-trend='glassmorphism'] body::before {
   z-index: 20;
   isolation: isolate;
   display: grid;
-  gap: 0.85rem;
+  gap: 0;
   width: min(960px, calc(100% - 2rem));
   margin: 0 auto 2.25rem;
-  padding: 1rem 1.1rem 1.15rem;
   background: var(--trend-surface);
   backdrop-filter: var(--trend-blur);
   -webkit-backdrop-filter: var(--trend-blur);
@@ -546,6 +545,7 @@ html[data-trend='glassmorphism'] body::before {
   border-radius: var(--trend-radius);
   box-shadow: var(--trend-shadow);
   transition: var(--trend-transition, all 0.4s ease);
+  overflow: hidden;
 }
 
 html[data-trend='brutalism'] .trend-toggle {
@@ -554,12 +554,42 @@ html[data-trend='brutalism'] .trend-toggle {
   box-shadow: 5px 5px 0 var(--trend-border-accent);
 }
 
-.trend-toggle-intro {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 0.35rem 1rem;
+.trend-toggle-summary {
+  appearance: none;
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.85rem;
+  width: 100%;
+  margin: 0;
+  padding: 0.7rem 0.9rem;
+  text-align: left;
+  color: inherit;
+  background: transparent;
+  border: 0;
+  cursor: pointer;
+  transition: background-color 0.25s ease;
+}
+
+.trend-toggle-summary:hover {
+  background: color-mix(in srgb, var(--color-accent), transparent 92%);
+}
+
+.trend-toggle-summary:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: -2px;
+}
+
+.trend-toggle-summary-preview {
+  width: 3.4rem;
+  height: 2.2rem;
+  flex-shrink: 0;
+}
+
+.trend-toggle-summary-copy {
+  display: grid;
+  gap: 0.15rem;
+  min-width: 0;
 }
 
 .trend-toggle-kicker {
@@ -573,16 +603,73 @@ html[data-trend='brutalism'] .trend-toggle {
 
 .trend-toggle-current {
   margin: 0;
-  font-size: 0.82rem;
+  font-size: 0.9rem;
   font-weight: 600;
   color: var(--trend-toggle-btn);
   letter-spacing: 0.01em;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.trend-toggle-summary-action {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.55rem;
+  border: 1px solid var(--trend-toggle-btn-border);
+  border-radius: var(--trend-radius-sm);
+  background: var(--trend-toggle-btn-bg);
+  color: var(--trend-toggle-btn);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.trend-toggle-chevron {
+  width: 0.45rem;
+  height: 0.45rem;
+  border-right: 1.5px solid currentColor;
+  border-bottom: 1.5px solid currentColor;
+  transform: rotate(45deg) translateY(-1px);
+  transition: transform 0.25s ease;
+}
+
+.trend-toggle[data-expanded='true'] .trend-toggle-chevron {
+  transform: rotate(225deg) translateY(-1px);
+}
+
+.trend-toggle-panel {
+  padding: 0 0.9rem 0.95rem;
+  border-top: 1px solid color-mix(in srgb, var(--trend-border), transparent 35%);
+}
+
+.trend-toggle-panel[hidden] {
+  display: none;
+}
+
+.trend-toggle[data-expanded='true'] .trend-toggle-panel {
+  animation: trend-panel-in 0.28s ease;
+}
+
+@keyframes trend-panel-in {
+  from {
+    opacity: 0;
+    transform: translateY(-0.35rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 .trend-toggle-swatches {
   display: grid;
   grid-template-columns: repeat(6, minmax(0, 1fr));
   gap: 0.55rem;
+  padding-top: 0.85rem;
 }
 
 @media (max-width: 820px) {
@@ -594,11 +681,23 @@ html[data-trend='brutalism'] .trend-toggle {
 @media (max-width: 480px) {
   .trend-toggle {
     width: calc(100% - 1rem);
-    padding: 0.85rem 0.75rem 1rem;
+  }
+
+  .trend-toggle-summary {
+    gap: 0.65rem;
+    padding: 0.65rem 0.75rem;
+  }
+
+  .trend-toggle-panel {
+    padding: 0 0.75rem 0.85rem;
   }
 
   .trend-toggle-swatches {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .trend-toggle-action-label {
+    display: none;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Replaces the old text-chip **Design Era** toolbar with a visual **swatch picker**, plus expand/collapse so the homepage stays quiet by default.

Also pins Netlify’s Node version for Astro 5.

### Design Era behavior
- Collapsed (default): compact row with current era preview, label, and **Change**
- Expanded: full swatch grid; **Close**, Escape, or selecting an era collapses it again
- Mobile: chevron-only action; 2-column swatch grid when open
- Existing localStorage / `data-trend` theme switching is unchanged

### Netlify
Astro 5 needs Node `>=18.20.8`. Failing previews were on `18.16.0` from `.nvmrc`.

Only change in `netlify.toml`:

```toml
[build.environment]
  NODE_VERSION = "18.20.8"
```

`.nvmrc` on this branch is already `18.20.8`.

## Screenshots

Collapsed (desktop):

[Design Era collapsed](https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fera-collapsed.png)

Expanded (desktop):

[Design Era expanded](https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fera-expanded.png)

Collapsed (mobile):

[Design Era collapsed on mobile](https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fera-collapsed-mobile.png)

Expanded (mobile):

[Design Era expanded on mobile](https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fera-expanded-mobile.png)

## Test plan
- [ ] Homepage shows collapsed Design Era row by default
- [ ] Change expands the swatch grid; Close / Escape collapses it
- [ ] Selecting a swatch applies the theme and collapses the panel
- [ ] Refresh preserves the selected era
- [ ] Check desktop / mobile layouts
- [ ] Confirm Netlify Deploy Preview for this PR uses Node `>=18.20.8` and succeeds


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcc5a-e077-78e6-aedb-64f35b9a022c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

