### PR TITLE
Fix full-width header and footer on mobile

### DIFF
--- a/src/components/SiteFooter.astro
+++ b/src/components/SiteFooter.astro
@@ -1,5 +1,5 @@
-<footer class="bg-blog-header">
-  <div class="p-6 sm:flex justify-between items-center">
+<footer class="site-footer site-chrome bg-blog-header w-full">
+  <div class="site-footer-inner p-6 sm:flex justify-between items-center">
     <div class="left pt-6">
       <a
         class="text-2xl text-blog-bg pointer transition-colors duration-500"

--- a/src/components/SiteHeader.astro
+++ b/src/components/SiteHeader.astro
@@ -8,11 +8,11 @@ const base = import.meta.env.BASE_URL.endsWith('/')
 const headerTitle = title ? String(title) : 'Blog by Chetan Raj';
 ---
 
-<header class="site-header bg-blog-header h-64 relative">
+<header class="site-header site-chrome bg-blog-header h-64 relative w-full">
   <div
     class="flex flex-col items-center h-64 hero-text justify-center text-center text-blog-bg relative z-10"
   >
-    <div class="text-2xl w-3/4 transition-colors duration-500">
+    <div class="text-2xl max-w-3xl px-4 transition-colors duration-500">
       {headerTitle}
     </div>
     {

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -68,13 +68,11 @@ const {
   <body>
     <SiteHeader title={headerTitle} />
     <TrendToggle />
-    <section class="w-3/4 m-auto">
+    <div class="site-content">
       <main class="h-sc">
-        <div class="">
-          <slot />
-        </div>
+        <slot />
       </main>
-    </section>
+    </div>
     <SiteFooter />
   </body>
 </html>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -43,6 +43,15 @@ html[data-color-mode='dark'] {
 }
 
 @layer base {
+  html,
+  body {
+    width: 100%;
+    max-width: 100%;
+    margin: 0;
+    padding: 0;
+    overflow-x: clip;
+  }
+
   body {
     @apply font-sans;
     background-color: var(--bg-color);
@@ -51,6 +60,36 @@ html[data-color-mode='dark'] {
 
   header {
     transition: color 0.6s, background-color 0.6s;
+  }
+}
+
+.site-chrome {
+  width: 100%;
+  max-width: none;
+  margin-left: 0;
+  margin-right: 0;
+}
+
+.site-content {
+  width: 100%;
+  max-width: 72rem;
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: 1rem;
+  padding-right: 1rem;
+}
+
+.site-footer-inner {
+  width: 100%;
+  max-width: 72rem;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+@media (min-width: 640px) {
+  .site-content {
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
   }
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The page used a `w-3/4` container that left large white gutters on mobile, making the header and footer feel inset even when their backgrounds were technically full width.

## Changes

- Header and footer use explicit `site-chrome` full-bleed styles (`width: 100%`, no max-width)
- Main content uses `site-content` with horizontal padding instead of `w-3/4` side margins
- Footer inner layout constrained with `site-footer-inner` while the background stays edge-to-edge
- Header title uses `max-w-3xl px-4` instead of `w-3/4`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcc5a-e077-78e6-aedb-64f35b9a022c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

