### PR TITLE
Restore readable content width with full-bleed header/footer

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -32,7 +32,7 @@ const {
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <script is:inline>
       (() => {
         const root = document.documentElement;

--- a/src/pages/posts/[...slug].astro
+++ b/src/pages/posts/[...slug].astro
@@ -62,7 +62,7 @@ const showUpdated =
       <div class="post-layout-main">
         <div class="blog-post-content">
           <div
-            class="mx-6 mt-4 mb-6 flex flex-wrap items-center gap-x-4 gap-y-3 text-blog-secondary"
+            class="post-meta mt-4 mb-6 flex flex-wrap items-center gap-x-4 gap-y-3 text-blog-secondary"
           >
             <time datetime={publishedTime} class="flex items-center justify-center">
               <svg

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,6 +17,8 @@
   --secondary-color: var(--color-secondary);
   --lightgray-color: var(--color-lightgray);
   --yellow: #f7df1e;
+  --site-column-width: min(75%, 60rem);
+  --site-gutter: 1.5rem;
 }
 
 .dark {
@@ -71,26 +73,15 @@ html[data-color-mode='dark'] {
 }
 
 .site-content {
-  width: 100%;
-  max-width: 72rem;
+  width: var(--site-column-width);
   margin-left: auto;
   margin-right: auto;
-  padding-left: 1rem;
-  padding-right: 1rem;
 }
 
 .site-footer-inner {
-  width: 100%;
-  max-width: 72rem;
+  width: var(--site-column-width);
   margin-left: auto;
   margin-right: auto;
-}
-
-@media (min-width: 640px) {
-  .site-content {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
-  }
 }
 
 .bg {
@@ -193,12 +184,12 @@ header .light {
 }
 
 .blog-post-content {
-  max-width: 960px;
-  margin: 0 auto;
+  width: 100%;
+  padding-inline: var(--site-gutter);
 }
 
 .post-toc {
-  margin: 0 1.5rem 1.75rem;
+  margin: 0 0 1.75rem;
   padding: 1rem 1.1rem;
   border: 1px solid var(--trend-border);
   border-radius: var(--trend-radius-sm);
@@ -256,7 +247,8 @@ header .light {
 .post-layout {
   display: grid;
   gap: 2rem;
-  max-width: 1100px;
+  width: 100%;
+  max-width: 100%;
   margin: 0 auto;
 }
 
@@ -345,7 +337,7 @@ header .light {
 .post-share,
 .author-blurb,
 .related-posts {
-  margin: 2rem 1.5rem 0;
+  margin: 2rem 0 0;
   padding-top: 1.5rem;
   border-top: 1px solid var(--trend-border);
 }
@@ -443,8 +435,8 @@ header .light {
 }
 
 .blog-post-content > *:not(img) {
-  margin-left: 1.5rem;
-  margin-right: 1.5rem;
+  margin-left: 0;
+  margin-right: 0;
   margin-bottom: 1.25em;
 }
 
@@ -499,7 +491,7 @@ header .light {
 .blog-post-content hr {
   border: 0;
   border-top: 1px solid var(--trend-border);
-  margin: 2rem 1.5rem;
+  margin: 2rem 0;
 }
 
 .new {

--- a/src/styles/trends.css
+++ b/src/styles/trends.css
@@ -536,7 +536,7 @@ html[data-trend='glassmorphism'] body::before {
   isolation: isolate;
   display: grid;
   gap: 0;
-  width: min(960px, calc(100% - 2rem));
+  width: var(--site-column-width);
   margin: 0 auto 2.25rem;
   background: var(--trend-surface);
   backdrop-filter: var(--trend-blur);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

PR #42 fixed header/footer bleed but set content to `width: 100%; max-width: 72rem`, which made blog posts stretch nearly full-screen. The original `w-3/4` readable column was lost.

## Fix

- Introduce `--site-column-width: min(75%, 60rem)` shared across content, Design Era picker, and footer inner layout
- Keep header/footer as full-bleed `site-chrome` (edge-to-edge backgrounds)
- Remove stacked horizontal margins on post pages (`mx-6` + child margins) that inflated content width
- Align post layout, TOC, and share/author blocks to the single content column

## Result

- Header/footer: full viewport width
- Blog content: ~75% centered column (original feel)
- Design Era block: aligned with content column

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcc5a-e077-78e6-aedb-64f35b9a022c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

