### PR TITLE
Fix mobile horizontal overflow on post pages

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -67,8 +67,8 @@ const {
   </head>
   <body>
     <SiteHeader title={headerTitle} />
-    <TrendToggle />
     <div class="site-content">
+      <TrendToggle />
       <main class="h-sc">
         <slot />
       </main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -17,8 +17,9 @@
   --secondary-color: var(--color-secondary);
   --lightgray-color: var(--color-lightgray);
   --yellow: #f7df1e;
-  --site-column-width: min(75%, 60rem);
-  --site-gutter: 1.5rem;
+  --site-column-max: 60rem;
+  --site-column-ratio: 75%;
+  --site-gutter: 1rem;
 }
 
 .dark {
@@ -45,16 +46,22 @@ html[data-color-mode='dark'] {
 }
 
 @layer base {
-  html,
-  body {
+  html {
     width: 100%;
     max-width: 100%;
+    overflow-x: hidden;
+  }
+
+  html,
+  body {
     margin: 0;
     padding: 0;
-    overflow-x: clip;
   }
 
   body {
+    width: 100%;
+    max-width: 100%;
+    overflow-x: hidden;
     @apply font-sans;
     background-color: var(--bg-color);
     transition: color 0.6s, background-color 0.6s;
@@ -62,6 +69,12 @@ html[data-color-mode='dark'] {
 
   header {
     transition: color 0.6s, background-color 0.6s;
+  }
+
+  *,
+  *::before,
+  *::after {
+    box-sizing: border-box;
   }
 }
 
@@ -73,15 +86,32 @@ html[data-color-mode='dark'] {
 }
 
 .site-content {
-  width: var(--site-column-width);
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
+  max-width: min(var(--site-column-max), var(--site-column-ratio));
+  margin-inline: auto;
+  padding-inline: var(--site-gutter);
+  min-width: 0;
 }
 
 .site-footer-inner {
-  width: var(--site-column-width);
-  margin-left: auto;
-  margin-right: auto;
+  width: 100%;
+  max-width: min(var(--site-column-max), var(--site-column-ratio));
+  margin-inline: auto;
+  padding-inline: var(--site-gutter);
+  min-width: 0;
+}
+
+@media (min-width: 768px) {
+  :root {
+    --site-gutter: 1.5rem;
+  }
+}
+
+@media (max-width: 767px) {
+  .site-content,
+  .site-footer-inner {
+    max-width: 100%;
+  }
 }
 
 .bg {
@@ -183,9 +213,15 @@ header .light {
   margin: 0;
 }
 
+.blog-post-container {
+  min-width: 0;
+  max-width: 100%;
+}
+
 .blog-post-content {
   width: 100%;
-  padding-inline: var(--site-gutter);
+  min-width: 0;
+  max-width: 100%;
 }
 
 .post-toc {
@@ -249,7 +285,25 @@ header .light {
   gap: 2rem;
   width: 100%;
   max-width: 100%;
+  min-width: 0;
   margin: 0 auto;
+}
+
+.post-layout-main {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.post-meta {
+  min-width: 0;
+  max-width: 100%;
+}
+
+.blog-post-body {
+  min-width: 0;
+  max-width: 100%;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
 }
 
 .post-toc-aside {
@@ -448,6 +502,7 @@ header .light {
   border-radius: var(--trend-radius-sm);
   box-shadow: var(--trend-shadow);
   overflow-x: auto;
+  max-width: 100%;
 }
 
 .blog-post-content code:not(pre code) {
@@ -485,7 +540,9 @@ header .light {
 .blog-post-content li {
   margin: 0.55rem 0;
   list-style: disc;
-  margin-left: 2em;
+  margin-left: 1.25em;
+  padding-right: 0.25em;
+  overflow-wrap: break-word;
 }
 
 .blog-post-content hr {

--- a/src/styles/trends.css
+++ b/src/styles/trends.css
@@ -536,8 +536,9 @@ html[data-trend='glassmorphism'] body::before {
   isolation: isolate;
   display: grid;
   gap: 0;
-  width: var(--site-column-width);
-  margin: 0 auto 2.25rem;
+  width: 100%;
+  max-width: 100%;
+  margin: 0 0 2.25rem;
   background: var(--trend-surface);
   backdrop-filter: var(--trend-blur);
   -webkit-backdrop-filter: var(--trend-blur);
@@ -679,10 +680,6 @@ html[data-trend='brutalism'] .trend-toggle {
 }
 
 @media (max-width: 480px) {
-  .trend-toggle {
-    width: calc(100% - 1rem);
-  }
-
   .trend-toggle-summary {
     gap: 0.65rem;
     padding: 0.65rem 0.75rem;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On mobile, post text and the TOC were clipped on the right edge. Nested `75%` width containers plus inner padding caused content to exceed the viewport.

## Fix

- Move Design Era picker inside `site-content` so it shares one column with posts
- Use `width: 100%` + `max-width: min(60rem, 75%)` + horizontal padding on mobile
- Add `min-width: 0`, `overflow-wrap`, and `overflow-x: hidden` guards on layout containers
- Remove duplicate padding on `.blog-post-content`
- Let trend toggle fill its parent column (`width: 100%`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcc5a-e077-78e6-aedb-64f35b9a022c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

