### PR TITLE
Blend scroll progress ring into footer at page bottom

### DIFF
--- a/src/components/ScrollProgress.astro
+++ b/src/components/ScrollProgress.astro
@@ -8,6 +8,7 @@
 <script>
   const root = document.querySelector('.scroll-progress');
   const bar = document.querySelector<SVGCircleElement>('.scroll-progress-bar');
+  const footer = document.querySelector('.site-footer');
 
   if (root && bar) {
     const radius = 15.5;
@@ -16,17 +17,28 @@
     bar.style.strokeDasharray = `${circumference}`;
     bar.style.strokeDashoffset = `${circumference}`;
 
+    const overlapsFooter = () => {
+      if (!footer) return false;
+
+      const footerRect = footer.getBoundingClientRect();
+      const circleRect = root.getBoundingClientRect();
+      const circleCenterY = circleRect.top + circleRect.height / 2;
+
+      return circleCenterY >= footerRect.top;
+    };
+
     const update = () => {
       const scrollable = document.documentElement.scrollHeight - window.innerHeight;
 
       if (scrollable <= 0) {
-        root.classList.remove('is-visible');
+        root.classList.remove('is-visible', 'is-over-footer');
         return;
       }
 
       const progress = window.scrollY / scrollable;
       bar.style.strokeDashoffset = `${circumference * (1 - progress)}`;
       root.classList.toggle('is-visible', window.scrollY > 24);
+      root.classList.toggle('is-over-footer', overlapsFooter());
     };
 
     update();

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -585,12 +585,15 @@ header .light {
   width: 100%;
   height: 100%;
   transform: rotate(-90deg);
+  border-radius: 50%;
+  transition: background-color 0.25s ease;
 }
 
 .scroll-progress-track {
   fill: none;
   stroke: color-mix(in srgb, var(--trend-border), transparent 20%);
   stroke-width: 2.5;
+  transition: stroke 0.25s ease;
 }
 
 .scroll-progress-bar {
@@ -598,7 +601,17 @@ header .light {
   stroke: var(--color-accent);
   stroke-width: 2.5;
   stroke-linecap: round;
-  transition: stroke-dashoffset 0.12s linear;
+  transition:
+    stroke-dashoffset 0.12s linear,
+    stroke 0.25s ease;
+}
+
+.scroll-progress.is-over-footer .scroll-progress-svg {
+  background-color: var(--header-bg);
+}
+
+.scroll-progress.is-over-footer .scroll-progress-track {
+  stroke: var(--header-bg);
 }
 
 @media (min-width: 768px) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
When the scroll progress ring overlaps the footer, its track stroke and circular backdrop switch to `var(--header-bg)` so the ring visually merges into the footer instead of showing a contrasting border.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcc5a-e077-78e6-aedb-64f35b9a022c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

