### PR TITLE
fix: Vercel preview base path for /blog

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,6 @@ yarn-error.log
 
 # Local Netlify folder
 .netlify
+
+# Vercel
+.vercel

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,27 @@
+{
+  "redirects": [
+    {
+      "source": "/",
+      "destination": "/blog/",
+      "permanent": false
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/blog",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/blog/",
+      "destination": "/index.html"
+    },
+    {
+      "source": "/blog/:path*/",
+      "destination": "/:path*/index.html"
+    },
+    {
+      "source": "/blog/:path*",
+      "destination": "/:path*"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Vercel previews (e.g. https://blog-six-sigma-34.vercel.app/) looked broken even though the build succeeded.

Astro is configured with `base: '/blog/'` for production on `chetanraj.dev/blog/`, so HTML references assets and pages under `/blog/...`. Vercel serves `dist` at the deploy root (`/`), so those URLs 404'd (unstyled homepage, dead post links).

## Fix

Add `vercel.json`:

- Redirect `/` → `/blog/`
- Rewrite `/blog` and `/blog/` → `index.html`
- Rewrite trailing-slash routes (`/blog/:path*/`) → `/:path*/index.html`
- Rewrite other `/blog/:path*` → `/:path*`

## Verified

After deploy:

- `/` → 307 → `/blog/`
- `/blog/` → 200
- `/blog/posts/how-i-structure-react-app/` → 200
- `/blog/_astro/*.css` → 200

## Test plan

- [ ] Open Vercel preview root URL — should land on homepage with styles
- [ ] Click a post — should load under `/blog/posts/...`
- [ ] Confirm production on chetanraj.dev/blog is unchanged (this only affects Vercel routing)