### PR TITLE
Fix deploy workflow actor for Cloud Agent merges

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,14 +5,16 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Only chetanraj can deploy — skips for bots, dependabot, or other collaborators.
+# Deploys on main pushes (e.g. merged PRs) or manual runs by the repo owner.
 concurrency:
   group: deploy-gh-pages
   cancel-in-progress: true
 
 jobs:
   deploy:
-    if: github.actor == 'chetanraj'
+    if: |
+      (github.event_name == 'workflow_dispatch' && github.actor == 'chetanraj') ||
+      (github.event_name == 'push' && contains(fromJSON('["chetanraj", "cursor[bot]"]'), github.actor))
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Merges via Cursor Cloud Agent run as `cursor[bot]`, so the deploy job was skipped after PR #50.

- **Push to main:** allowed actors: `chetanraj`, `cursor[bot]`
- **Manual dispatch:** still only `chetanraj`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcc5a-e077-78e6-aedb-64f35b9a022c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcc5a-e077-78e6-aedb-64f35b9a022c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

