### PR TITLE
feat: harsh-gradient post grid with tiles and cards

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,8 +1,9 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { Badge, Link, Stack, Text } from '@capper-ui/react';
+import { Badge, Text } from '@capper-ui/react';
 import { getCollection } from 'astro:content';
 import { SITE } from '../site.config';
+import { gradientStyle, harshGradientFor } from '../utils/gradients';
 
 const base = import.meta.env.BASE_URL.endsWith('/')
   ? import.meta.env.BASE_URL
@@ -10,8 +11,6 @@ const base = import.meta.env.BASE_URL.endsWith('/')
 const posts = (await getCollection('posts'))
   .filter((post) => post.data.published !== false)
   .sort((a, b) => b.data.date.getTime() - a.data.date.getTime());
-
-const [latestPost, ...otherPosts] = posts;
 ---
 
 <BaseLayout
@@ -19,82 +18,117 @@ const [latestPost, ...otherPosts] = posts;
   description={SITE.description}
   path="/"
 >
-  <Text as="h2" size="3xl" weight="regular" className="index-section-title">
-    Latest post
-  </Text>
+  <section
+    class="index-board"
+    data-index-view="tiles"
+    data-index-cols="2"
+    aria-label="Blog posts"
+  >
+    <div class="index-board-toolbar">
+      <Text as="h2" size="3xl" weight="regular" className="index-section-title">
+        Posts
+      </Text>
 
-  {
-    latestPost &&
-      (() => {
-        const daysSince = Math.floor(
-          (Date.now() - latestPost.data.date.getTime()) / (1000 * 60 * 60 * 24)
-        );
-        const isNew = daysSince < 35;
-        return (
-          <Link href={`${base}posts/${latestPost.slug}/`} className="index-post-link">
-            <Stack gap="sm" className="index-post-preview">
-              <Text as="span" size="2xl" weight="regular" className="index-post-title">
-                {latestPost.data.title}
-              </Text>
-              <Text as="span" color="muted" className="index-post-description">
-                {latestPost.data.description}
-              </Text>
-              <Text as="span" size="sm" color="subtle" className="index-post-meta">
-                wrote on {latestPost.data.date.toISOString().slice(0, 10)}
-                {isNew ? (
-                  <span class="index-post-new">
-                    {' '}
-                    · <Badge variant="accent" size="sm">New</Badge>
-                  </span>
-                ) : (
-                  ''
-                )}
-              </Text>
-            </Stack>
-          </Link>
-        );
-      })()
-  }
+      <div class="index-board-controls">
+        <div class="index-control" role="group" aria-label="Post layout">
+          <span class="index-control-label">Layout</span>
+          <button type="button" class="index-chip" data-index-set-view="tiles" aria-pressed="true">
+            Tiles
+          </button>
+          <button type="button" class="index-chip" data-index-set-view="cards" aria-pressed="false">
+            Cards
+          </button>
+        </div>
+        <div class="index-control" role="group" aria-label="Grid density">
+          <span class="index-control-label">Grid</span>
+          <button type="button" class="index-chip" data-index-set-cols="2" aria-pressed="true">
+            2 × 2
+          </button>
+          <button type="button" class="index-chip" data-index-set-cols="3" aria-pressed="false">
+            3 × 3
+          </button>
+        </div>
+      </div>
+    </div>
 
-  <Text as="h2" size="3xl" weight="regular" className="index-section-title">
-    Other posts
-  </Text>
-
-  <Stack as="ul" gap="md" className="index-post-list">
-    {
-      otherPosts.map((post) =>
-        (() => {
+    <ul class="index-board-grid">
+      {
+        posts.map((post) => {
           const daysSince = Math.floor(
             (Date.now() - post.data.date.getTime()) / (1000 * 60 * 60 * 24)
           );
           const isNew = daysSince < 35;
+          const gradient = harshGradientFor(post.slug);
           return (
             <li>
-              <Link href={`${base}posts/${post.slug}/`} className="index-post-link">
-                <Stack gap="sm" className="index-post-preview">
-                  <Text as="span" size="2xl" weight="regular" className="index-post-title">
-                    {post.data.title}
-                  </Text>
-                  <Text as="span" color="muted" className="index-post-description">
-                    {post.data.description}
-                  </Text>
-                  <Text as="span" size="sm" color="subtle" className="index-post-meta">
+              <a
+                class="index-post-cell"
+                href={`${base}posts/${post.slug}/`}
+                style={gradientStyle(gradient)}
+              >
+                <span class="index-post-wash" aria-hidden="true"></span>
+                <span class="index-post-body">
+                  <span class="index-post-title">{post.data.title}</span>
+                  {post.data.description && (
+                    <span class="index-post-description">{post.data.description}</span>
+                  )}
+                  <span class="index-post-meta">
                     wrote on {post.data.date.toISOString().slice(0, 10)}
                     {isNew ? (
                       <span class="index-post-new">
                         {' '}
                         · <Badge variant="accent" size="sm">New</Badge>
                       </span>
-                    ) : (
-                      ''
-                    )}
-                  </Text>
-                </Stack>
-              </Link>
+                    ) : null}
+                  </span>
+                </span>
+              </a>
             </li>
           );
-        })()
-      )
-    }
-  </Stack>
+        })
+      }
+    </ul>
+  </section>
 </BaseLayout>
+
+<script is:inline>
+  (() => {
+    const board = document.querySelector('.index-board');
+    if (!board) return;
+
+    const VIEW_KEY = 'blog-index-view';
+    const COLS_KEY = 'blog-index-cols';
+
+    const apply = (view, cols) => {
+      const nextView = view === 'cards' ? 'cards' : 'tiles';
+      const nextCols = cols === '3' ? '3' : '2';
+      board.dataset.indexView = nextView;
+      board.dataset.indexCols = nextCols;
+      board.querySelectorAll('[data-index-set-view]').forEach((btn) => {
+        btn.setAttribute('aria-pressed', String(btn.getAttribute('data-index-set-view') === nextView));
+      });
+      board.querySelectorAll('[data-index-set-cols]').forEach((btn) => {
+        btn.setAttribute('aria-pressed', String(btn.getAttribute('data-index-set-cols') === nextCols));
+      });
+    };
+
+    apply(window.localStorage.getItem(VIEW_KEY), window.localStorage.getItem(COLS_KEY));
+
+    board.addEventListener('click', (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const viewBtn = target.closest('[data-index-set-view]');
+      const colsBtn = target.closest('[data-index-set-cols]');
+      if (viewBtn) {
+        const view = viewBtn.getAttribute('data-index-set-view');
+        window.localStorage.setItem(VIEW_KEY, view || 'tiles');
+        apply(view, board.dataset.indexCols);
+      }
+      if (colsBtn) {
+        const cols = colsBtn.getAttribute('data-index-set-cols');
+        window.localStorage.setItem(COLS_KEY, cols || '2');
+        apply(board.dataset.indexView, cols);
+      }
+    });
+  })();
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -379,6 +379,208 @@ header .light {
   padding: 0;
 }
 
+.site-content:has(.index-board) {
+  max-width: min(72rem, 94%);
+}
+
+.index-board-toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.index-board-toolbar .index-section-title {
+  margin: 1.5rem 0 0;
+}
+
+.index-board-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.index-control {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.index-control-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--color-lightgray);
+}
+
+.index-chip {
+  appearance: none;
+  border: 1px solid currentColor;
+  background: transparent;
+  color: var(--color-primary);
+  font-size: 0.875rem;
+  font-weight: 600;
+  line-height: 1.25rem;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.5rem;
+  cursor: pointer;
+  transition: transform 0.7s cubic-bezier(0.32, 0.72, 0, 1),
+    background-color 0.7s cubic-bezier(0.32, 0.72, 0, 1),
+    color 0.7s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.index-chip:hover {
+  transform: translateY(-1px);
+}
+
+.index-chip:active {
+  transform: scale(0.98);
+}
+
+.index-chip:focus-visible {
+  outline: 2px solid var(--color-accent, #f7df1e);
+  outline-offset: 2px;
+}
+
+.index-chip[aria-pressed='true'] {
+  background: var(--color-primary);
+  color: var(--color-bg);
+  border-color: var(--color-primary);
+}
+
+.index-board-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .index-board[data-index-cols='2'] .index-board-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .index-board[data-index-cols='3'] .index-board-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+.index-post-cell {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 16rem;
+  min-width: 0;
+  overflow: hidden;
+  text-decoration: none;
+  color: inherit;
+  border-radius: 1rem;
+  isolation: isolate;
+  transition: transform 0.7s cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.index-post-cell:hover {
+  transform: translateY(-4px);
+}
+
+.index-post-cell:active {
+  transform: scale(0.98);
+}
+
+.index-post-cell:focus-visible {
+  outline: 2px solid var(--color-accent, #f7df1e);
+  outline-offset: 3px;
+}
+
+.index-post-wash {
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  background: linear-gradient(
+    var(--g-angle, 36deg),
+    var(--g-a) 0%,
+    var(--g-a) 42%,
+    var(--g-b) 58%,
+    var(--g-b) 100%
+  );
+}
+
+.index-post-body {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+  padding: 1.5rem;
+  min-width: 0;
+}
+
+.index-board[data-index-view='tiles'] .index-post-title,
+.index-board[data-index-view='tiles'] .index-post-description,
+.index-board[data-index-view='tiles'] .index-post-meta {
+  color: var(--g-ink);
+  text-wrap: pretty;
+}
+
+.index-board[data-index-view='tiles'] .index-post-title {
+  font-size: 1.5rem;
+  line-height: 2rem;
+  font-weight: 600;
+  text-wrap: balance;
+}
+
+.index-board[data-index-view='tiles'] .index-post-description {
+  font-size: 1rem;
+  line-height: 1.5rem;
+  opacity: 0.9;
+}
+
+.index-board[data-index-cols='3'] .index-post-cell {
+  min-height: 14rem;
+}
+
+/* Card view: Capper-like surface, gradient as a top bar */
+.index-board[data-index-view='cards'] .index-post-cell {
+  background: var(--trend-surface, var(--color-bg));
+  box-shadow: 0 1px 2px rgb(0 0 0 / 8%), 0 8px 24px rgb(0 0 0 / 6%);
+  min-height: 0;
+}
+
+.index-board[data-index-view='cards'] .index-post-wash {
+  inset: 0 0 auto;
+  height: 0.5rem;
+}
+
+.index-board[data-index-view='cards'] .index-post-body {
+  padding-top: 1.25rem;
+}
+
+.index-board[data-index-view='cards'] .index-post-title {
+  color: var(--color-primary);
+  font-size: 1.25rem;
+  line-height: 1.75rem;
+  font-weight: 600;
+  text-wrap: balance;
+}
+
+.index-board[data-index-view='cards'] .index-post-description {
+  color: var(--color-secondary);
+  font-size: 0.875rem;
+  line-height: 1.25rem;
+  text-wrap: pretty;
+}
+
+.index-board[data-index-view='cards'] .index-post-meta {
+  color: var(--color-lightgray);
+  margin-top: auto;
+}
+
 .site-footer-brand {
   font-size: 1.5rem;
   line-height: 1.2;

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -502,10 +502,8 @@ header .light {
   inset: 0;
   z-index: 0;
   background: linear-gradient(
-    var(--g-angle, 36deg),
+    var(--g-angle, 160deg),
     var(--g-a) 0%,
-    var(--g-a) 42%,
-    var(--g-b) 58%,
     var(--g-b) 100%
   );
 }

--- a/src/utils/gradients.ts
+++ b/src/utils/gradients.ts
@@ -1,24 +1,24 @@
-export type HarshGradient = {
+export type PostGradient = {
   a: string;
   b: string;
   ink: string;
   angle: number;
 };
 
-/** High-chroma pairs with little mid-blend. One pair per post, from slug. */
-const PALETTE: Omit<HarshGradient, 'angle'>[] = [
-  { a: '#f7df1e', b: '#111111', ink: '#111111' },
-  { a: '#ff2d95', b: '#00f0ff', ink: '#111111' },
-  { a: '#ff4d00', b: '#5b00ff', ink: '#ffffff' },
-  { a: '#00ff9d', b: '#1a0033', ink: '#ffffff' },
-  { a: '#ffe600', b: '#ff006e', ink: '#111111' },
-  { a: '#00d4ff', b: '#0011ff', ink: '#ffffff' },
-  { a: '#c8ff00', b: '#ff3d00', ink: '#111111' },
-  { a: '#ffffff', b: '#ff00aa', ink: '#111111' },
-  { a: '#7cfc00', b: '#8b00ff', ink: '#111111' },
-  { a: '#ffd500', b: '#0033ff', ink: '#111111' },
-  { a: '#ff0066', b: '#111111', ink: '#ffffff' },
-  { a: '#00ffcc', b: '#ff4d00', ink: '#111111' },
+/** Soft tints of the blog header blue (#0f4c81 / #dfebf6). */
+const PALETTE: Omit<PostGradient, 'angle'>[] = [
+  { a: '#0f4c81', b: '#7eafd0', ink: '#ffffff' },
+  { a: '#dfebf6', b: '#0f4c81', ink: '#0f4c81' },
+  { a: '#163e66', b: '#9bc4dc', ink: '#ffffff' },
+  { a: '#4a8ab8', b: '#0f4c81', ink: '#ffffff' },
+  { a: '#c5dcec', b: '#1e5f96', ink: '#0f4c81' },
+  { a: '#2d6a9f', b: '#e8f2f8', ink: '#ffffff' },
+  { a: '#5a9bc4', b: '#0f4c81', ink: '#ffffff' },
+  { a: '#e8f2f8', b: '#4a8ab8', ink: '#0f4c81' },
+  { a: '#0f4c81', b: '#dfebf6', ink: '#ffffff' },
+  { a: '#9bc4dc', b: '#163e66', ink: '#0f4c81' },
+  { a: '#1e5f96', b: '#b8d4e8', ink: '#ffffff' },
+  { a: '#7eafd0', b: '#163e66', ink: '#0f4c81' },
 ];
 
 function hashSlug(slug: string): number {
@@ -29,14 +29,14 @@ function hashSlug(slug: string): number {
   return h;
 }
 
-export function harshGradientFor(slug: string): HarshGradient {
+export function harshGradientFor(slug: string): PostGradient {
   const h = hashSlug(slug);
   const base = PALETTE[h % PALETTE.length];
-  const angle = 18 + (h % 7) * 18;
+  const angle = 150 + (h % 5) * 8;
   return { ...base, angle };
 }
 
-export function gradientStyle(gradient: HarshGradient): string {
+export function gradientStyle(gradient: PostGradient): string {
   return [
     `--g-a:${gradient.a}`,
     `--g-b:${gradient.b}`,

--- a/src/utils/gradients.ts
+++ b/src/utils/gradients.ts
@@ -1,0 +1,46 @@
+export type HarshGradient = {
+  a: string;
+  b: string;
+  ink: string;
+  angle: number;
+};
+
+/** High-chroma pairs with little mid-blend. One pair per post, from slug. */
+const PALETTE: Omit<HarshGradient, 'angle'>[] = [
+  { a: '#f7df1e', b: '#111111', ink: '#111111' },
+  { a: '#ff2d95', b: '#00f0ff', ink: '#111111' },
+  { a: '#ff4d00', b: '#5b00ff', ink: '#ffffff' },
+  { a: '#00ff9d', b: '#1a0033', ink: '#ffffff' },
+  { a: '#ffe600', b: '#ff006e', ink: '#111111' },
+  { a: '#00d4ff', b: '#0011ff', ink: '#ffffff' },
+  { a: '#c8ff00', b: '#ff3d00', ink: '#111111' },
+  { a: '#ffffff', b: '#ff00aa', ink: '#111111' },
+  { a: '#7cfc00', b: '#8b00ff', ink: '#111111' },
+  { a: '#ffd500', b: '#0033ff', ink: '#111111' },
+  { a: '#ff0066', b: '#111111', ink: '#ffffff' },
+  { a: '#00ffcc', b: '#ff4d00', ink: '#111111' },
+];
+
+function hashSlug(slug: string): number {
+  let h = 0;
+  for (let i = 0; i < slug.length; i += 1) {
+    h = (h * 31 + slug.charCodeAt(i)) >>> 0;
+  }
+  return h;
+}
+
+export function harshGradientFor(slug: string): HarshGradient {
+  const h = hashSlug(slug);
+  const base = PALETTE[h % PALETTE.length];
+  const angle = 18 + (h % 7) * 18;
+  return { ...base, angle };
+}
+
+export function gradientStyle(gradient: HarshGradient): string {
+  return [
+    `--g-a:${gradient.a}`,
+    `--g-b:${gradient.b}`,
+    `--g-ink:${gradient.ink}`,
+    `--g-angle:${gradient.angle}deg`,
+  ].join(';');
+}


### PR DESCRIPTION
## Summary

Index posts sit in a 2×2 or 3×3 board. Each cell has a unique harsh gradient (hashed from the slug). A toolbar switches **Tiles** (full wash) vs **Cards** (Capper-like surface with an 8px gradient bar). Preference is stored in `localStorage`.

Mobile stays one column; 2 / 3 apply from 768px up.

## Preview

Vercel / Netlify will attach a deploy preview to this branch.